### PR TITLE
Add draft version of schedule

### DIFF
--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -11,12 +11,13 @@ nav_title: Schedule
 |-------------|------------------------------------------------|
 | **Day 1**   | **2020-06-22** <br> [Introduction to R and the Tidyverse](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/README.md)                      
 | 12:00       | Welcome, Introductions and Getting Started  |
-| 12:30       | [Introduction to base R](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/01-intro_to_base_R.nb.html) with [additional exercises](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/04a-intro_to_R_exercise.Rmd) |
-|             | [Introduction to ggplot2](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html) |
+| 12:30       | [Introduction to base R](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/01-intro_to_base_R.nb.html) |
+|             | [Introduction to R Exercise](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/04a-intro_to_R_exercise.Rmd)
 | 3:30 		 | [Consultation session](workshop-structure.md#consultation-sessions) begins |
 | 5:00        | End             |
 | **Day 2**   | **2020-06-23** <br> [Introduction to R and the Tidyverse](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/README.md)      |
-| 12:00       | [Introduction to the Tidyverse](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html) |
+| 12:00      | [Introduction to ggplot2](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html) |
+|             | [Introduction to the Tidyverse](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html) |
 |             | [Introduction to Tidyverse Exercises - part 1](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/04b-intro_to_tidyverse_exercise-part-1.Rmd) |
 |             | [Introduction to Tidyverse Exercises - part 2](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/04c-intro_to_tidyverse_exercise-part-2.Rmd) |
 | 3:30        | [Consultation session](workshop-structure.md#consultation-sessions) begins |

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -29,12 +29,12 @@ nav_title: Schedule
 | 3:30        | [Consultation session](workshop-structure.md#consultation-sessions) begins |
 | 5:00        | End             |        
 | **Day 4**   | **2020-06-25** <br> [Introduction to Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/RNA-seq/README.md) | 
-| 12:00       | Exercise: [Neuroblastoma Cell Line tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) |
+| 12:00       | Exercise: [Neuroblastoma Cell Line tximport](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/RNA-seq/04-nb_cell_line_tximport.md) |
 | 1:30        | Bulk RNA-seq IV: [Differential Expression Analysis](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
 | 3:15        | [Bulk RNA-seq Exercise](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/RNA-seq/06-bulk_rnaseq_exercise.Rmd) |
 | 3:30        | [Consultation session](workshop-structure.md#consultation-sessions) begins |
 | 5:00        | End             |
 | **Day 5**   | **2020-06-36** <br> Consultation and Presentations |
 | 12:00       | [Consultation session](workshop-structure.md#consultation-sessions) begins |
-| 2:30        | [Presentations begin](workshop-structure.md#) |
+| 2:30        | [Presentations begin](workshop-structure.md#presentations) |
 | 5:00        | Adjourn   |

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -5,13 +5,35 @@ nav_title: Schedule
 
 <!--See an example from a past virtual workshop here: https://github.com/AlexsLemonade/2020-may-training/wiki/Schedule --> 
 
+*Draft schedule subject to changes*
+
 | Time        | Topic                                          |
 |-------------|------------------------------------------------|
-| **Day 1**   | **Date** <br> [Module]()                      |
-| 12:00 PM    | Welcome, Introductions and Getting Started     <br>[Welcome Slides (PDF)](../slides/ Workshop_Introduction.pdf)|
+| **Day 1**   | **2020-06-22** <br> [Introduction to R and the Tidyverse](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/README.md)                      
+| 12:00       | Welcome, Introductions and Getting Started  |
+| 12:30       | [Introduction to base R](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/01-intro_to_base_R.nb.html) with [additional exercises](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/04a-intro_to_R_exercise.Rmd) |
+|             | [Introduction to ggplot2](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html) |
+| 3:30 		 | [Consultation session](workshop-structure.md#consultation-sessions) begins |
 | 5:00        | End             |
-| **Day 2**   | **Date**  | 
-| **Day 3**   | **Date**  |               
-| **Day 4**   | **Date**  | 
-| **Day 5**   | **Date**  |     
+| **Day 2**   | **2020-06-23** <br> [Introduction to R and the Tidyverse](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/README.md)      |
+| 12:00       | [Introduction to the Tidyverse](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html) |
+|             | [Introduction to Tidyverse Exercises - part 1](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/04b-intro_to_tidyverse_exercise-part-1.Rmd) |
+|             | [Introduction to Tidyverse Exercises - part 2](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/04c-intro_to_tidyverse_exercise-part-2.Rmd) |
+| 3:30        | [Consultation session](workshop-structure.md#consultation-sessions) begins |
+| 5:00        | End             |
+| **Day 3**   | **2020-06-24** <br> [Introduction to Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/RNA-seq/README.md) |    
+| 12:00       | Bulk RNA-seq I: [QC, trim, and quantification with Salmon](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/RNA-seq/01-qc_trim_quant.md)            |
+| 1:30       | Bulk RNA-seq II: [Gene-Level Summaries with tximport](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/RNA-seq/02-gastric_cancer_tximport.nb.html) |
+| 2:30        | Bulk RNA-seq III: [Exploratory Analyses](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/RNA-seq/03-gastric_cancer_exploratory.nb.html) |   
+| 3:30        | [Consultation session](workshop-structure.md#consultation-sessions) begins |
+| 5:00        | End             |        
+| **Day 4**   | **2020-06-25** <br> [Introduction to Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/RNA-seq/README.md) | 
+| 12:00       | Exercise: [Neuroblastoma Cell Line tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md) |
+| 1:30        | Bulk RNA-seq IV: [Differential Expression Analysis](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
+| 3:15        | [Bulk RNA-seq Exercise](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/RNA-seq/06-bulk_rnaseq_exercise.Rmd) |
+| 3:30        | [Consultation session](workshop-structure.md#consultation-sessions) begins |
+| 5:00        | End             |
+| **Day 5**   | **2020-06-36** <br> Consultation and Presentations |
+| 12:00       | [Consultation session](workshop-structure.md#consultation-sessions) begins |
+| 2:30        | [Presentations begin](workshop-structure.md#) |
 | 5:00        | Adjourn   |


### PR DESCRIPTION
But future proof some links with `{{site.release_tag}}` (currently `master`; #3). This version of the schedule is intended to give folks an idea of what the structure and content of the workshop, but is subject to change with the addition of daily exercises.

Closes #1.