### PR TITLE
Add Docker repo and tag for this training

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -13,8 +13,8 @@ end_date: 2020-06-26
 release_tag: master
 # The Docker user will almost always be ccdl, which is why this is here
 docker_user: ccdl
-docker_repo: DOCKER-REPOSITORY
-docker_tag: DOCKER-TAG
+docker_repo: training_rnaseq
+docker_tag: 2020-june
 # These are for loading Docker images from a file; only relevant for in-person
 docker_targz: ccdl_docker_image.tar.gz
 docker_tar: ccdl_docker_image.tar


### PR DESCRIPTION
I tagged the `latest` image (same as `2020-may-virtual`) with `2020-june` and pushed it to Docker Hub: https://hub.docker.com/r/ccdl/training_rnaseq/tags. These variables are used in the documentation about using Docker post-workshop.